### PR TITLE
chore: enable corepack and initialize ci

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description
+
+Please provide a brief summary of the changes made in this pull request.
+
+Fixes # (issue reference, if applicable)
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+
+- [ ] Locally tested the according endpoints
+- [ ] Ran E2E-Tests
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Continious Integration
+
+on:
+  pull_request:
+    branches: ['main']
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: './package.json'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Checks
+        run: pnpm check
+
+      - name: Run Lint
+        run: pnpm lint
+
+      - name: Run Build
+        run: pnpm build

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ node_modules
 .env
 .env.*
 !.env.example
+renovate.json
 
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,28 +1,20 @@
-# create-svelte
-
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte).
-
-## Creating a project
-
-If you're seeing this, you've probably already done this step. Congrats!
-
-```bash
-# create a new project in the current directory
-npm create svelte@latest
-
-# create a new project in my-app
-npm create svelte@latest my-app
-```
-
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+If you cloned the repository locally run `corepack enable` to setup the correct version of the package manager. After running `corepack enable` you can use `pnpm` to install dependencies and run scripts.
+
+First, install the dependencies:
 
 ```bash
-npm run dev
+pnpm install
+```
+
+Then, run the development server:
+
+```bash
+pnpm run dev
 
 # or start the server and open the app in a new browser tab
-npm run dev -- --open
+pnpm run dev -- --open
 ```
 
 ## Building
@@ -30,9 +22,29 @@ npm run dev -- --open
 To create a production version of your app:
 
 ```bash
-npm run build
+pnpm run build
 ```
 
-You can preview the production build with `npm run preview`.
+You can preview the production build with `pnpm run preview`.
 
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+## Contributing
+
+To contribute to this template, clone this repository locally and commit your code on a separate branch. Try using conventional commits. When you're ready to make a commit, run the following command to check if your changes meet the standards:
+
+```bash
+pnpm prep-commit
+```
+
+If the checks pass, stage the files you want to commit and run the following command:
+
+```bash
+git commit -m "Your commit message"
+```
+
+If you're satisfied with your changes and are ready to merge them, run the following command to ensure your changes pass in our CI-Pipeline:
+
+```bash
+pnpm prep-pr
+```
+
+If the checks pass open a pull request on the `main` branch. Once the pull request is approved and merged, your changes will be automatically deployed to production.

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
 	"version": "0.0.1",
 	"private": true,
 	"engines": {
-		"node": "^19.9.0"
+		"node": "^19.9.0",
+		"pnpm": "^8.5.0"
 	},
+	"packageManager": "pnpm@8.5.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -12,7 +14,9 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
-		"format": "prettier --plugin-search-dir . --write ."
+		"format": "prettier --plugin-search-dir . --write .",
+		"prep-commit": "pnpm check && pnpm format",
+		"prep-pr": "pnpm check && pnpm lint && pnpm build"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^2.0.0",


### PR DESCRIPTION
Noch ein bisschen Setup für das Repository, beinhaltet:

1. CI GitHub-Action
2. Corepack-Unterstützung, müsstet theoretisch nur noch corepack installieren und `corepack enable` ausführen, wenn ihr das Repo zum ersten mal benutzt. Das sollte sich um die richtigen Verisonen kümmern. :)
3. Bevor ihr Änderungen commited, könnt ihr `pnpm prep-commit` ausführen, das checkt nach Svelte-Fehlern und linted euren Code
4. Bevor ihr einen Pull Request aufmacht, könnt ihr lokal `pnpm prep-pr` ausführen, das führt die selben Checks durch wie die CI-Action. 